### PR TITLE
expiration for items is in milliseconds instead of seconds

### DIFF
--- a/src/main/scala/net/lag/kestrel/QueueCollection.scala
+++ b/src/main/scala/net/lag/kestrel/QueueCollection.scala
@@ -114,7 +114,7 @@ class QueueCollection(queueFolder: String, private var queueConfigs: ConfigMap) 
         val normalizedExpiry: Long = if (expiry == 0) {
           0
         } else if (expiry < 1000000) {
-          now + expiry
+          now + (expiry * 1000)
         } else {
           expiry
         }


### PR DESCRIPTION
The docs say "When they come from a client, expiration times are handled in the same way as memcache: if the number is small (less than one million), it's interpreted as a relative number of seconds from now. Otherwise it's interpreted as an absolute unix epoch time, in seconds since the beginning of 1 January 1970 GMT."

But based on my testing of setting a timeout of 3600, which should be 1 hour, it actually times out rather quickly, looking into the code I don't see where the expiry is multiplied by 1000 to convert it to ms before it gets normalized in QueueCollection:add().
