### PR TITLE
Add version, stats and dump stats to text protocol.  Sorta kinda test it...

### DIFF
--- a/src/test/scala/net/lag/kestrel/TextHandlerSpec.scala
+++ b/src/test/scala/net/lag/kestrel/TextHandlerSpec.scala
@@ -78,6 +78,11 @@ class TextHandlerSpec extends Specification with JMocker with ClassMocker {
       val (codec, counter) = TestCodec(TextCodec.read, TextCodec.write)
       codec.send(ItemResponse(Some("hello".getBytes))) mustEqual List(":hello\n")
     }
+
+    "string response" in {
+        val (codec, counter) = TestCodec(TextCodec.read, TextCodec.write)
+        codec.send(StringResponse("hello")) mustEqual List("+hello\n")
+    }
   }
 
   "TextHandler" should {


### PR DESCRIPTION
I tested the new response class I made, but I didn't know see an example of the version/stats/dump_stats to see how to properly test that.  I'm not really a Scala guy, but I can copy it and adapt it a bit. ;)

That response class might be a bad idea.

I'm sure blatantly copying the stats and dump_stats code from the other handler is a bad idea, since it should likely be put in some common place.

This might not be useful, but I thought I'd send it along.  Thanks either way!
