### PR TITLE
Use specified queue for prefill in 'flood' test

### DIFF
--- a/src/test/scala/net/lag/kestrel/load/Flood.scala
+++ b/src/test/scala/net/lag/kestrel/load/Flood.scala
@@ -121,8 +121,7 @@ object Flood extends LoadTesting {
     if (prefillItems > 0) {
       println("prefill: " + prefillItems + " items of " + kilobytes + "kB")
       val socket = SocketChannel.open(new InetSocketAddress(hostname, 22133))
-      val qName = "spam"
-      put(socket, qName, prefillItems, data)
+      put(socket, queueName, prefillItems, data)
     }
 
     println("flood: " + totalItems + " items of " + kilobytes + "kB into " + queueName)


### PR DESCRIPTION
This just fixes a bug introduced when the prefill option was merged (because that merge happened after the change to let you specify the queue name, so it still had "spam" hardcoded).
