### PR TITLE
Detect additional corrupt journal cases

### DIFF
--- a/src/main/scala/net/lag/kestrel/Kestrel.scala
+++ b/src/main/scala/net/lag/kestrel/Kestrel.scala
@@ -197,12 +197,18 @@ object Kestrel {
   val sessionId = new AtomicInteger()
 
   def main(args: Array[String]): Unit = {
-    runtime = RuntimeEnvironment(this, args)
-    kestrel = runtime.loadRuntimeConfig[Kestrel]()
+    try {
+      runtime = RuntimeEnvironment(this, args)
+      kestrel = runtime.loadRuntimeConfig[Kestrel]()
 
-    Stats.addGauge("connections") { sessions.get().toDouble }
+      Stats.addGauge("connections") { sessions.get().toDouble }
 
-    kestrel.start()
+      kestrel.start()
+    } catch {
+      case e =>
+        log.error(e, "Exception during startup; exiting!")
+        System.exit(1)
+    }
     log.info("Kestrel %s started.", runtime.jarVersion)
   }
 


### PR DESCRIPTION
I ran into a case of a busted journal transaction (due to the filesystem filling up...), which prevented kestrel from starting up. It manifested as a `NegativeArraySizeException` in `QItem.unpackOldAdd()`; see https://gist.github.com/1f697ac37e7102b952cb. Since this happened during startup, it resulted in an undead kestrel instance--it was running but Netty wasn't set up so it couldn't do anything.

So there are 2 fixes here:

1) Do length checks in `QItem.unpack()` and `QItem.unpackOldAdd()` so that we throw IOException in this case and that gets treated correctly as a broken journal entry and lets things proceed. (Also in this case `Journal.readBlock()` had returned a zero-length block--perhaps that should throw an exception too, but I wasn't sure.)

2) If we throw an exception during the setup in `main()`, just `System.exit(1)`. (Calling the clean shutdown API didn't work out-of-the-box since some of the things it was trying to shut down were not set up so it just NPE'd, but there might be some more graceful solution possible than just exit-ing.)

In my case there wasn't really an old-style-CMD_ADD in the journal I'd imagine, and probably just some null bytes being misinterpreted. I guess this isn't alarming, since probably all bets are off if the filesystem fills up, though it's not obvious to me how that would lead to null bytes at that spot in the journal.
