### PR TITLE
maxExpireSweep should be worked for background-expiration process

### DIFF
--- a/src/main/scala/net/lag/kestrel/Kestrel.scala
+++ b/src/main/scala/net/lag/kestrel/Kestrel.scala
@@ -139,7 +139,7 @@ class Kestrel(defaultQueueConfig: QueueConfig, builders: List[QueueBuilder],
       log.info("Starting up background expiration task.")
       new PeriodicBackgroundProcess("background-expiration", expirationTimerFrequency.get) {
         def periodic() {
-          val expired = Kestrel.this.queueCollection.flushAllExpired()
+          val expired = Kestrel.this.queueCollection.flushAllExpired(true)
           if (expired > 0) {
             log.info("Expired %d item(s) from queues automatically.", expired)
           }

--- a/src/main/scala/net/lag/kestrel/QueueCollection.scala
+++ b/src/main/scala/net/lag/kestrel/QueueCollection.scala
@@ -182,16 +182,16 @@ class QueueCollection(queueFolder: String, timer: Timer, journalSyncTimer: Timer
     }
   }
 
-  def flushExpired(name: String): Int = {
+  def flushExpired(name: String, limit: Boolean = false): Int = {
     if (shuttingDown) {
       0
     } else {
-      queue(name) map { q => q.discardExpired(q.config.maxExpireSweep) } getOrElse(0)
+      queue(name) map { q => q.discardExpired(limit) } getOrElse(0)
     }
   }
 
-  def flushAllExpired(): Int = {
-    queueNames.foldLeft(0) { (sum, qName) => sum + flushExpired(qName) }
+  def flushAllExpired(limit: Boolean = false): Int = {
+    queueNames.foldLeft(0) { (sum, qName) => sum + flushExpired(qName, limit) }
   }
 
   def stats(key: String): Array[(String, String)] = queue(key) match {


### PR DESCRIPTION
Currently, maxExpireSweep does not work as written to this document.
http://robey.github.com/kestrel/docs/guide.html
I think that maxExpireSweep should be worked only for a background-expiration (sweeping) process.
I just wrote so, regards.
