### PR TITLE
Removing metrics for queues

### DIFF
--- a/project/build/KestrelProject.scala
+++ b/project/build/KestrelProject.scala
@@ -11,7 +11,7 @@ class KestrelProject(info: ProjectInfo) extends StandardServiceProject(info) wit
   val utilEval =    "com.twitter" % "util-eval"    % "1.12.4"
   val utilLogging = "com.twitter" % "util-logging" % "1.12.4"
 
-  val ostrich = "com.twitter" % "ostrich" % "4.10.0"
+  val ostrich = "com.twitter" % "ostrich" % "4.10.3"
   val naggati = "com.twitter" % "naggati" % "2.1.1" intransitive() // allow custom netty
   val netty   = "org.jboss.netty" % "netty" % "3.2.6.Final"
 

--- a/src/main/scala/net/lag/kestrel/PersistentQueue.scala
+++ b/src/main/scala/net/lag/kestrel/PersistentQueue.scala
@@ -404,6 +404,7 @@ class PersistentQueue(val name: String, persistencePath: String, @volatile var c
     Stats.clearGauge(statNamed("age_msec"))
     Stats.clearGauge(statNamed("waiters"))
     Stats.clearGauge(statNamed("open_transactions"))
+    Stats.clearGauge(statNamed("create_time"))
     Stats.removeMetric(statNamed("set_latency_usec"))
     Stats.removeMetric(statNamed("get_timeout_msec"))
     Stats.removeMetric(statNamed("delivery_latency_msec"))


### PR DESCRIPTION
This patch doesn't seem to work until a newer ostrich is included with Kestrel, but there are a lot of queue metrics hanging around post-deletion in 2.1.5.

I had trouble testing this because I can't seem to get the latest version of Ostrich into Kestrel because one is using 2.9.1 and the other 2.8.1.

I'll just leave this here until it can be applied?
