### PR TITLE
fixes a bug on PersistentQueueSpec.scala

### DIFF
--- a/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
+++ b/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
@@ -714,8 +714,8 @@ class PersistentQueueSpec extends Specification
           val configWithoutMaxExpireSweep = new QueueBuilder {
             keepJournal = false
           }.apply()
-          val r = new PersistentQueue("vocaloid", folderName, configWithoutMaxExpireSweep, timer, timer)
-          val q = new PersistentQueue("wu_tang", folderName, configWithMaxExpireSweep, timer, timer)
+          val r = new PersistentQueue("vocaloid", folderName, configWithoutMaxExpireSweep, timer, scheduler)
+          val q = new PersistentQueue("wu_tang", folderName, configWithMaxExpireSweep, timer, scheduler)
           r.setup()
           q.setup()
 


### PR DESCRIPTION
`sbt test` fails because of invalid arguments on PersistentQueueSpec.scala.

```
[info] == test-compile ==
[info]   Source analysis: 1 new/modified, 0 indirectly invalidated, 0 removed.
[info] Compiling test sources...
[info] 'compiler-interface' not yet compiled for Scala 2.8.1.final. Compiling...
[info]   Compilation completed in 5.485 s
[error] /home/???/kestrel/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala:717: type mismatch;
[error]  found   : net.lag.kestrel.FakeTimer
[error]  required: java.util.concurrent.ScheduledExecutorService
[error]           val r = new PersistentQueue("vocaloid", folderName, configWithoutMaxExpireSweep, timer, timer)
[error]                                                                                                   ^
[error] one error found
```
