### PR TITLE
Un-removed stats

### DIFF
--- a/src/main/scala/net/lag/kestrel/PersistentQueue.scala
+++ b/src/main/scala/net/lag/kestrel/PersistentQueue.scala
@@ -426,6 +426,10 @@ class PersistentQueue(val name: String, persistencePath: String, @volatile var c
   // Remove various stats related to the queue
   def removeStats() {
     Stats.removeCounter(statNamed("total_items"))
+    Stats.removeCounter(statNamed("get_items_hit"))
+    Stats.removeCounter(statNamed("get_items_miss"))
+    Stats.removeCounter(statNamed("put_bytes"))
+    Stats.removeCounter(statNamed("put_items"))
     Stats.removeCounter(statNamed("expired_items"))
     Stats.removeCounter(statNamed("discarded"))
     Stats.removeCounter(statNamed("total_flushes"))


### PR DESCRIPTION
There are a couple of new stats not being cleared when queues are deleted. This clears those out.  This will eventually OOM Ostrich if kestrel has a lot of deleted queues if my past experiences are correct.
