### PR TITLE
Support for GETS memcached protocol command

### DIFF
--- a/src/main/scala/net/lag/kestrel/MemcacheHandler.scala
+++ b/src/main/scala/net/lag/kestrel/MemcacheHandler.scala
@@ -58,7 +58,7 @@ class MemcacheHandler(
 
   final def apply(request: MemcacheRequest): Future[MemcacheResponse] = {
     request.line(0) match {
-      case "get" =>
+      case "get" | "gets" =>
         get(request.line(1))
       case "monitor" =>
         val maxItems = if (request.line.size > 3) request.line(3).toInt else maxOpenReads


### PR DESCRIPTION
Add support for the "gets" memcached command
https://github.com/memcached/memcached/blob/master/doc/protocol.txt
allows kestrel to work with enyim memcached client and others
