### PR TITLE
Update performance test scripts with correct test jar

### DIFF
--- a/src/scripts/load/leaky-reader
+++ b/src/scripts/load/leaky-reader
@@ -1,4 +1,4 @@
 #!/bin/bash
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
-TEST_JAR=$DIST_HOME/kestrel-tests-@VERSION@.jar
+TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.LeakyThriftReader "$@"

--- a/src/scripts/load/many-clients
+++ b/src/scripts/load/many-clients
@@ -1,4 +1,4 @@
 #!/bin/bash
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
-TEST_JAR=$DIST_HOME/kestrel-tests-@VERSION@.jar
+TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.ManyClients "$@"

--- a/src/scripts/load/packing
+++ b/src/scripts/load/packing
@@ -1,4 +1,4 @@
 #!/bin/bash
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
-TEST_JAR=$DIST_HOME/kestrel-tests-@VERSION@.jar
+TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.JournalPacking "$@"

--- a/src/scripts/load/put-many
+++ b/src/scripts/load/put-many
@@ -1,4 +1,4 @@
 #!/bin/bash
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
-TEST_JAR=$DIST_HOME/kestrel-tests-@VERSION@.jar
+TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.PutMany "$@"


### PR DESCRIPTION
Some of performance test scripts had the wrong TEST_JAR listed. Fixed that.
