### PR TITLE
Debian/Ubuntu support for start/stop script

### DIFF
--- a/src/scripts/kestrel.sh
+++ b/src/scripts/kestrel.sh
@@ -39,7 +39,7 @@ daemon_pidfile="/var/run/$APP_NAME/$APP_NAME-daemon.pid"
 
 
 running() {
-  kill -0 `cat $pidfile`
+  kill -0 `cat $pidfile` > /dev/null 2>&1
 }
 
 find_java() {


### PR DESCRIPTION
With these changes the start/stop script should work out of the box on Debian/Ubuntu systems.
