### PR TITLE
Use sh instead of bash in portable scripts

### DIFF
--- a/src/scripts/devel.sh
+++ b/src/scripts/devel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 echo "Starting kestrel in development mode..."
 
 # find jar no matter what the root dir name

--- a/src/scripts/load/flood
+++ b/src/scripts/load/flood
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
 TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.Flood "$@"

--- a/src/scripts/load/leaky-reader
+++ b/src/scripts/load/leaky-reader
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
 TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.LeakyThriftReader "$@"

--- a/src/scripts/load/many-clients
+++ b/src/scripts/load/many-clients
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
 TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.ManyClients "$@"

--- a/src/scripts/load/packing
+++ b/src/scripts/load/packing
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
 TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.JournalPacking "$@"

--- a/src/scripts/load/put-many
+++ b/src/scripts/load/put-many
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 DIST_HOME="$(dirname $(readlink $0 || echo $0))/../.."
 TEST_JAR=$DIST_HOME/@DIST_NAME@-@VERSION@-test.jar
 java -server -classpath @DIST_CLASSPATH@:$TEST_JAR net.lag.kestrel.load.PutMany "$@"


### PR DESCRIPTION
Hi!

Some test scripts in kestrel use bash as an interpreter in the shebang line while they don't use any bash specific features.  I changes them to rely on the POSIX shell instead.
