### PR TITLE
adding correct return codes to kestrel.sh status

### DIFF
--- a/src/scripts/kestrel.sh
+++ b/src/scripts/kestrel.sh
@@ -137,8 +137,10 @@ case "$1" in
   status)
     if running; then
       echo "$APP_NAME is running."
+      exit 0
     else
       echo "$APP_NAME is NOT running."
+      exit 3
     fi
   ;;
 


### PR DESCRIPTION
added correct status codes to `kestrel.sh status`, fixing #119
