### PR TITLE
Pin SBT Version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.2


### PR DESCRIPTION
SBT plugins (scrooge, package-dist) used in Kestrel are very much dependent on
the sbt version, so pinning it to the last compatible SBT version to avoid
build failures.
