### PR TITLE
Update currentAge for queue on add

### DIFF
--- a/src/main/scala/net/lag/kestrel/PersistentQueue.scala
+++ b/src/main/scala/net/lag/kestrel/PersistentQueue.scala
@@ -551,6 +551,7 @@ class PersistentQueue(val name: String, persistencePath: String, @volatile var c
     putBytes.getAndAdd(item.data.length)
     queueSize += item.data.length
     queueLength += 1
+    _currentAge = item.addTime
   }
 
   private def _peek(): Option[QItem] = {
@@ -569,7 +570,6 @@ class PersistentQueue(val name: String, persistencePath: String, @volatile var c
     _memoryBytes -= len
     queueLength -= 1
     fillReadBehind()
-    _currentAge = item.addTime
     if (transaction) {
       item.xid = xid.getOrElse { nextXid() }
       openTransactions(item.xid) = item


### PR DESCRIPTION
Right now `_currentAge` is not updated on a queue until an item is removed.

This means if the queue had items, then went to 0, when the next item is added, the queue age will not reflect the `addTime` of the only item in the queue, but instead the add time of the last item before it went to 0.
