### PR TITLE
restric sbt build version

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,6 @@ The startup script logs extensive GC information to a file named `stdout` in
 the log folder. If kestrel has problems starting up (before it can initialize
 logging), it will usually appear in `error` in the same folder.
 
-Options dependency:
-   specs :https://github.com/vongosling/specs/tree/specs-2.8.0/src/main/scala/org/specs
-
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Kestrel
 =======
 
@@ -129,6 +128,9 @@ journal files into `/var/spool/kestrel/`.
 The startup script logs extensive GC information to a file named `stdout` in
 the log folder. If kestrel has problems starting up (before it can initialize
 logging), it will usually appear in `error` in the same folder.
+
+Options dependency:
+   specs :https://github.com/vongosling/specs/tree/specs-2.8.0/src/main/scala/org/specs
 
 
 Configuration

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.2


### PR DESCRIPTION
Restrict sbt build version to be compliant with the twitter customized sbt plugin
